### PR TITLE
fix: Correct port in HTTPRoute for example-3.com

### DIFF
--- a/cka-tasks/gateway-api/route-examples/example-3.yaml
+++ b/cka-tasks/gateway-api/route-examples/example-3.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-3
+spec:
+  parentRefs:
+  - name: gateway
+  hostnames:
+  - "example3.com"
+  rules:
+  # Verification: $ curl -H "Host: example3.com" 127.0.0.1:8080/pod-3
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /pod-3
+    filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: /
+    backendRefs:
+    - name: service-3
+      port: 8080


### PR DESCRIPTION
This commit corrects the backend port in the HTTPRoute resource defined in `cka-tasks/gateway-api/route-examples/example-3.yaml`.

The port was previously set to `80`, but it has been changed to `8080` to be consistent with `example-2.yaml`, as requested by you.

No other files were modified.

Testing was not performed as `kubectl` is not available in the execution environment, which is required to apply and verify the Kubernetes resources.